### PR TITLE
settings: Protect sensitive info on About device

### DIFF
--- a/res/values/ppui_strings.xml
+++ b/res/values/ppui_strings.xml
@@ -34,4 +34,10 @@
     <!-- App details: open play store link if app is user installed -->
     <string name="app_play_store">Google Play</string>
 
+    <!-- Whether to show or hide sensitive info (like IMEI and Phone Number) on About phone -->
+    <bool name="configShowDeviceSensitiveInfo">false</bool>
+
+    <!-- String for removal of sensitive info on about, depending on tap -->
+    <string name="device_info_protected_single_press">Tap to show info</string>
+
 </resources>

--- a/src/com/android/settings/deviceinfo/PhoneNumberPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/PhoneNumberPreferenceController.java
@@ -47,6 +47,7 @@ public class PhoneNumberPreferenceController extends BasePreferenceController {
     private final TelephonyManager mTelephonyManager;
     private final SubscriptionManager mSubscriptionManager;
     private final List<Preference> mPreferenceList = new ArrayList<>();
+    private boolean mTapped = false;    
 
     public PhoneNumberPreferenceController(Context context, String key) {
         super(context, key);
@@ -61,7 +62,10 @@ public class PhoneNumberPreferenceController extends BasePreferenceController {
 
     @Override
     public CharSequence getSummary() {
-        return getFirstPhoneNumber();
+        if (mContext.getResources().getBoolean(R.bool.configShowDeviceSensitiveInfo) && mTapped) {
+            return getFirstPhoneNumber();
+        }
+        return mContext.getString(R.string.device_info_protected_single_press);
     }
 
     @Override
@@ -93,16 +97,28 @@ public class PhoneNumberPreferenceController extends BasePreferenceController {
 
     @Override
     public boolean isSliceable() {
-        return true;
+        return mTapped;
     }
 
     @Override
     public boolean isCopyableSlice() {
-        return true;
+       return mTapped;
     }
 
     @Override
     public boolean useDynamicSliceSummary() {
+       return mTapped;
+    }
+
+    @Override
+    public boolean handlePreferenceTreeClick(Preference preference) {
+        final int simSlotNumber = mPreferenceList.indexOf(preference);
+        if (simSlotNumber == -1) {
+            return false;
+        }
+        mTapped = true;
+        final Preference simStatusPreference = mPreferenceList.get(simSlotNumber);
+        simStatusPreference.setSummary(getPhoneNumber(simSlotNumber));
         return true;
     }
 
@@ -134,7 +150,10 @@ public class PhoneNumberPreferenceController extends BasePreferenceController {
             return mContext.getText(R.string.device_info_default);
         }
 
-        return getFormattedPhoneNumber(subscriptionInfo);
+        if (mContext.getResources().getBoolean(R.bool.configShowDeviceSensitiveInfo) || mTapped) {
+            return getFormattedPhoneNumber(subscriptionInfo);
+        }
+        return mContext.getString(R.string.device_info_protected_single_press);
     }
 
     private CharSequence getPreferenceTitle(int simSlot) {

--- a/src/com/android/settings/deviceinfo/imei/ImeiInfoPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/imei/ImeiInfoPreferenceController.java
@@ -97,8 +97,11 @@ public class ImeiInfoPreferenceController extends BasePreferenceController {
 
     private CharSequence getSummary(int simSlot) {
         final int phoneType = getPhoneType(simSlot);
-        return phoneType == PHONE_TYPE_CDMA ? mTelephonyManager.getMeid(simSlot)
-                : mTelephonyManager.getImei(simSlot);
+        if (mContext.getResources().getBoolean(R.bool.configShowDeviceSensitiveInfo)) {
+            return phoneType == PHONE_TYPE_CDMA ? mTelephonyManager.getMeid(simSlot)
+                    : mTelephonyManager.getImei(simSlot);
+        }
+        return mContext.getString(R.string.device_info_protected_single_press);
     }
 
     @Override


### PR DESCRIPTION
Tired of seeing people/see yourself editing every screenshot to hide some personal info like their phone numbers or their IMEI? Well, this commit will help by adding a custom string to inform the user that, to get that info, they should tap that preference. If you want to show them, you can make an overlay and set configShowDeviceSensitiveInfo as true.

Signed-off-by: Sipun Ku Mahanta <sipunkumar85@gmail.com>
Change-Id: If2d931212acc8fed6c502073dcf68a2920b595b7
Signed-off-by: Subinsmani <subins.mani@gmail.com>
Signed-off-by: ugly-kid-af <dwarmachine24@gmail.com>